### PR TITLE
Add newly created parent to ObjMaps

### DIFF
--- a/src/BootstrapTreeViewWidget/widget/BootstrapTreeViewWidget.js
+++ b/src/BootstrapTreeViewWidget/widget/BootstrapTreeViewWidget.js
@@ -443,6 +443,7 @@ define([
                         // No parent, add at highest level
                         this._createNode(this._ulMainElement, obj, this.mainNodeClass);
                         elementCreated = true;
+                        this._updateObjMaps(obj);
                     }
                 }
                 // In the next run, only process the objects that were skipped.


### PR DESCRIPTION
To prevent a parent node from being created on every following update the parent object should be added to the ObjMaps.